### PR TITLE
Fixes: Faceted countings are not updated for checkboxes widget if AND operator used

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,9 @@ Changelog
 
 5.4-dev - (unreleased)
 ----------------------
+* Bug fix: Fixed: Faceted countings are not updated for checkboxes
+  widget if AND operator is used
+  [hman refs #8061]
 * Bug fix: Fixed: Date widget doesn't update when value comes from URL
   [hman refs #8382]
 * Bug fix: Fixed: Bug in the Alphabetic widget

--- a/eea/facetednavigation/browser/app/counter.py
+++ b/eea/facetednavigation/browser/app/counter.py
@@ -27,14 +27,16 @@ class FacetedQueryCounter(object):
         kwargs.pop('sort[]', None)
         kwargs.pop('sort', None)
         kwargs.pop('reversed[]', None)
+        operator = kwargs.pop('operator', None)
 
-        kwargs.pop(cid, None)
-        self.request.form.pop(cid, None)
-        # jQuery >= 1.4 adds type to params keys
-        # $.param({ a: [2,3,4] }) // "a[]=2&a[]=3&a[]=4"
-        # Let's fix this
-        kwargs.pop(cid + '[]', None)
-        self.request.form.pop(cid + '[]', None)
+        if not operator or operator != 'and':
+            kwargs.pop(cid, None)
+            self.request.form.pop(cid, None)
+            # jQuery >= 1.4 adds type to params keys
+            # $.param({ a: [2,3,4] }) // "a[]=2&a[]=3&a[]=4"
+            # Let's fix this
+            kwargs.pop(cid + '[]', None)
+            self.request.form.pop(cid + '[]', None)
 
         criteria = ICriteria(self.context)
         criterion = criteria.get(cid)

--- a/eea/facetednavigation/widgets/checkbox/view.js
+++ b/eea/facetednavigation/widgets/checkbox/view.js
@@ -8,6 +8,7 @@ Faceted.CheckboxesWidget = function(wid){
   this.title = jQuery('legend', this.widget).html();
   this.elements = jQuery('input[type=checkbox]', this.widget);
   this.maxitems = parseInt(jQuery('span', this.widget).text(), 10);
+  this.operator = this.widget.attr('data-operator');
   this.selected = [];
 
   // Faceted version
@@ -58,7 +59,7 @@ Faceted.CheckboxesWidget = function(wid){
       js_widget.count(sortcountable);
     });
     jQuery(Faceted.Events).bind(Faceted.Events.FORM_DO_QUERY, function(evt, data){
-      if(data.wid == js_widget.wid || data.wid == 'b_start'){
+      if(js_widget.operator != 'and' && (data.wid == js_widget.wid || data.wid == 'b_start')){
         return;
       }
       js_widget.count(sortcountable);
@@ -176,6 +177,9 @@ Faceted.CheckboxesWidget.prototype = {
     query.cid = this.wid;
     if(this.version){
       query.version = this.version;
+    }
+    if(this.operator){
+      query.operator = this.operator;
     }
 
     var context = this;

--- a/eea/facetednavigation/widgets/checkbox/widget.pt
+++ b/eea/facetednavigation/widgets/checkbox/widget.pt
@@ -11,7 +11,7 @@
   css python:hidezerocount and css + ' faceted-zero-count-hidden' or css;
   css python:sortcountable and css + ' faceted-sortcountable' or css;
   maxitems python:view.data.get('maxitems', 0) or 0;"
-  tal:attributes="id string:${wid}_widget; class css">
+  tal:attributes="id string:${wid}_widget; class css; data-operator python:view.operator;">
 
 <fieldset class="widget-fieldset">
   <legend tal:define="title python:view.data.get('title', '')" tal:content="

--- a/eea/facetednavigation/widgets/checkbox/widget.py
+++ b/eea/facetednavigation/widgets/checkbox/widget.py
@@ -119,6 +119,12 @@ class Widget(CountableWidget):
                 return True
         return False
 
+    @property
+    def operator(self):
+        """ Get the query operator
+        """
+        return self.data.get('operator', 'and')
+
     def query(self, form):
         """ Get value from form and return a catalog dict query
         """
@@ -127,7 +133,7 @@ class Widget(CountableWidget):
         index = index.encode('utf-8', 'replace')
 
         # Use 'and' by default in order to be backward compatible
-        operator = self.data.get('operator', 'and')
+        operator = self.operator
         operator = operator.encode('utf-8', 'replace')
 
         if not index:


### PR DESCRIPTION
If the 'AND' operator is used for the checkbox widget, it fetches
new count results.
