### PR TITLE
feat(dx): conditionally query by unicode value

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 ----------------------
 * Bug fix: Added translations for 'Current filters'.
   [prospchr]
+* Feature: Radio and checkbox widgets query for unicode or encoded strings
+  depending on the availability of plone.app.contenttypes. This is a
+  requirement to work with dexterity
+  [do3cc]
 
 6.5 - (2013-11-20)
 ------------------

--- a/eea/facetednavigation/dexterity_support.py
+++ b/eea/facetednavigation/dexterity_support.py
@@ -1,0 +1,17 @@
+#coding=utf-8
+
+import pkg_resources
+try:
+    pkg_resources.get_distribution('plone.app.contenttypes')
+except pkg_resources.DistributionNotFound:
+    def normalize(value):
+        if isinstance(value, unicode):
+            return value.encode('utf-8')
+        else:
+            return value
+else:
+    def normalize(value):
+        if isinstance(value, str):
+            return value.decode('utf-8')
+        else:
+            return value

--- a/eea/facetednavigation/search/catalog.py
+++ b/eea/facetednavigation/search/catalog.py
@@ -22,6 +22,7 @@ class FacetedCatalog(object):
             return IIBucket(), (index_id,)
 
         rset = apply_index({index_id: value})
+
         if not rset:
             return IIBucket(), (index_id,)
 

--- a/eea/facetednavigation/widgets/checkbox/widget.py
+++ b/eea/facetednavigation/widgets/checkbox/widget.py
@@ -11,6 +11,7 @@ from Products.Archetypes.public import SelectionWidget
 from Products.Archetypes.public import BooleanWidget
 from Products.Archetypes.utils import DisplayList
 
+from eea.facetednavigation.dexterity_support import normalize as atdx_normalize
 from eea.facetednavigation.widgets import ViewPageTemplateFile
 from eea.faceted.vocabularies.utils import compare
 from eea.facetednavigation.widgets.widget import CountableWidget
@@ -162,6 +163,8 @@ class Widget(CountableWidget):
             value = self.default
         else:
             value = form.get(self.data.getId(), '')
+
+        value = atdx_normalize(value)
 
         if not value:
             return query

--- a/eea/facetednavigation/widgets/radio/widget.py
+++ b/eea/facetednavigation/widgets/radio/widget.py
@@ -9,9 +9,10 @@ from Products.Archetypes.public import IntegerWidget
 from Products.Archetypes.public import SelectionWidget
 from Products.Archetypes.public import BooleanWidget
 
+from eea.facetednavigation import EEAMessageFactory as _
+from eea.facetednavigation.dexterity_support import normalize as atdx_normalize
 from eea.facetednavigation.widgets import ViewPageTemplateFile
 from eea.facetednavigation.widgets.widget import CountableWidget
-from eea.facetednavigation import EEAMessageFactory as _
 
 
 EditSchema = Schema((
@@ -112,8 +113,7 @@ class Widget(CountableWidget):
         if not value:
             return query
 
-        if not isinstance(value, unicode):
-            value = value.decode('utf-8')
+        value = atdx_normalize(value)
 
-        query[index] = value.encode('utf-8')
+        query[index] = value
         return query

--- a/eea/facetednavigation/widgets/text/widget.py
+++ b/eea/facetednavigation/widgets/text/widget.py
@@ -1,15 +1,16 @@
 """ Text widget
 """
+from Products.Archetypes.Field import BooleanField
 from Products.Archetypes.public import Schema
 from Products.Archetypes.public import SelectionWidget
 from Products.Archetypes.public import StringField
 from Products.Archetypes.public import StringWidget
+from Products.Archetypes.Widget import BooleanWidget
 
+from eea.facetednavigation import EEAMessageFactory as _
+from eea.facetednavigation.dexterity_support import normalize as atdx_normalize
 from eea.facetednavigation.widgets import ViewPageTemplateFile
 from eea.facetednavigation.widgets.widget import Widget as AbstractWidget
-from eea.facetednavigation import EEAMessageFactory as _
-from Products.Archetypes.Field import BooleanField
-from Products.Archetypes.Widget import BooleanWidget
 
 
 EditSchema = Schema((

--- a/eea/facetednavigation/widgets/widget.py
+++ b/eea/facetednavigation/widgets/widget.py
@@ -23,9 +23,10 @@ from Products.Archetypes.public import SelectionWidget
 
 from eea.facetednavigation.interfaces import IFacetedCatalog
 
+from eea.facetednavigation import EEAMessageFactory as _
+from eea.facetednavigation.dexterity_support import normalize as atdx_normalize
 from eea.facetednavigation.interfaces import ILanguageWidgetAdapter
 from eea.facetednavigation.widgets.interfaces import IWidget
-from eea.facetednavigation import EEAMessageFactory as _
 
 def compare(a, b):
     """ Compare lower values
@@ -368,18 +369,15 @@ class CountableWidget(Widget):
             if not value:
                 res[value] = len(brains)
                 continue
-            if isinstance(value, unicode):
-                try:
-                    value = value.encode('utf-8')
-                except Exception:
-                    continue
-            rset = ctool.apply_index(self.context, index, value)[0]
+            normalized_value = atdx_normalize(value)
+            rset = ctool.apply_index(self.context, index, normalized_value)[0]
             rset = IISet(rset)
             rset = weightedIntersection(brains, rset)[1]
-            if isinstance(value, str):
-                try:
-                    value = value.decode('utf-8')
-                except Exception:
-                    continue
-            res[value] = len(rset)
+            if isinstance(value, unicode):
+                res[value] = len(rset)
+            elif isinstance(normalized_value, unicode):
+                res[normalized_value] = len(rset)
+            else:
+                unicode_value = value.decode('utf-8')
+                res[unicode_value] = len(rset)
         return res


### PR DESCRIPTION
Keyword indexes get their values stored as unicode strings if the objects to be indexed are dexterity type objects. Finally!
AT stores its values as encoded strings. This leads to problematic coexistence (http://stackoverflow.com/a/6152209/39345), but don't tell that one of our sites, it might get nervous.

Anyway. Because it is dangerous to mix AT and DX types, this code assumes that if plone.app.contenttypes is available, the site is a DX only site. If people think they can mix and match AT and DX, they have to monkey patch anyway.

Since DX will be the standard type in the future, the changes are written in such a way that it is easily possible to identify AT compatibility code and remove AT compatibility code somewhere in the far future easily.

The slightly weird method definition in dexterity_support ensures that the check for dexterity has only to be done once during import time.

There is a slight change in behavior in widget.py
formerly, there was a catchall exception, (except Exception: will catch ConflictErrors!)
Which would pass on the value unchanged. This does not happen any longer.
If a value cannot be encoded from unicode to an utf-8 encoded string, bad things are happening.
