### PR TITLE
radio and checkbox widgets are not displayed if vocabulary is empty

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,7 +3,12 @@ Changelog
 
 6.8-dev - (unreleased)
 ----------------------
-* Feature: plone.app.contenttypes-compatability for select and tagcloud widgets
+
+* Fix: for consistency with select widget, radio and checkbox widgets
+  are not displayed if vocabulary is empty.
+  [thomasdesvenain]
+
+* Feature: plone.app.contenttypes-compatibility for select and tagcloud widgets.
   [pbauer]
 
 6.7 - (2014-01-29)

--- a/eea/facetednavigation/widgets/checkbox/widget.pt
+++ b/eea/facetednavigation/widgets/checkbox/widget.pt
@@ -13,7 +13,9 @@
   maxitems python:view.data.get('maxitems', 0) or 0;
   operator python:view.operator;
   operator_visible python:view.operator_visible;
-  operator_lable python: 'any' if operator == 'or' else 'all'"
+  operator_lable python: 'any' if operator == 'or' else 'all';
+  vocabulary view/vocabulary;"
+  tal:condition="vocabulary"
   tal:attributes="id string:${wid}_widget; class css; data-operator python:operator;">
 
 <fieldset class="widget-fieldset">
@@ -34,7 +36,7 @@
   <form action="." method="get">
 
   <ul>
-    <tal:items repeat="term python:view.vocabulary()">
+    <tal:items repeat="term vocabulary">
       <li tal:define="
         term_id python:term[0];
         term_label python:term[1];

--- a/eea/facetednavigation/widgets/radio/widget.pt
+++ b/eea/facetednavigation/widgets/radio/widget.pt
@@ -11,7 +11,9 @@
   css python:view.countable and css + ' faceted-count' or css;
   css python:hidezerocount and css + ' faceted-zero-count-hidden' or css;
   css python:sortcountable and css + ' faceted-sortcountable' or css;
-  maxitems python:view.data.get('maxitems', 0) or 0;"
+  maxitems python:view.data.get('maxitems', 0) or 0;
+  vocabulary view/vocabulary;"
+  tal:condition="vocabulary"
   tal:attributes="id string:${wid}_widget; class css">
 
 <fieldset class="widget-fieldset">
@@ -32,7 +34,7 @@
           i18n:translate="" i18n:attributes="title">All</label>
       </tal:terms>
     </li>
-    <tal:items repeat="term python:view.vocabulary()">
+    <tal:items repeat="term vocabulary">
       <li tal:define="
         term_id python:term[0];
         term_label python:term[1];


### PR DESCRIPTION
Fix: for consistency with select widget, radio and checkbox widgets are not displayed if vocabulary is empty.
