### PR TITLE
Make it possible to reset the date filter

### DIFF
--- a/eea/facetednavigation/widgets/daterange/view.js
+++ b/eea/facetednavigation/widgets/daterange/view.js
@@ -39,6 +39,30 @@ Faceted.DateRangeWidget = function(wid){
     }
   });
 
+  /**
+   * Make sure we can reset the date range by manually deleting the start and
+   * end value of the date range and call the 'onChange' event (click outside
+   * the changed field).
+   */
+  this.start.change(function(){
+    var start = js_widget.start.val();
+    var end = js_widget.end.val();
+
+    if(!start && !end){
+      js_widget.reset();
+      Faceted.Form.do_query(js_widget.wid, []);
+    }
+  });
+  this.end.change(function(){
+    var start = js_widget.start.val();
+    var end = js_widget.end.val();
+
+    if(!start && !end){
+      js_widget.reset();
+      Faceted.Form.do_query(js_widget.wid, []);
+    }
+  });
+
   // Handle clicks
   jQuery('form', this.widget).submit(function(){
     return false;
@@ -61,6 +85,16 @@ Faceted.DateRangeWidget.prototype = {
   do_query: function(element){
     var start = this.start.val();
     var end = this.end.val();
+
+    /**
+     * Make sure we can reset the date range by manually deleting the start and
+     * end value of the date range and running the query (press enter).
+     */
+    if(!start && !end){
+      this.reset();
+      Faceted.Form.do_query(this.wid, []);
+    }
+
     if(!start || !end){
       this.selected = [];
       return false;


### PR DESCRIPTION
Right now, there is no (clean) way to reset the date range filter, as deleting the start and end date simply doesn't do anything and if you re-run the query the dates are just populated again from the GET parameters. 

We changed it so the date range resets when both fields are cleared, allowing you to manually delete both fields by keyboard and reset the filter.
