### PR TITLE
Take the 'purge' parameter into account in the xml file importing criteria

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,10 @@ Changelog
 
 8.2 - (2015-08-18)
 ------------------
+* Feature: in the GenericSetup import step, make the "purge" parameter work
+  at the "criteria" level, for now it was always purged, it is now possible
+  to not purge and add extra criteria
+  [gbastien]
 * Feature: make boolean index work well with checkbox widget.
   [cedricmessiant]
 
@@ -724,4 +728,3 @@ Changelog
 1.0 (2009-10-30)
 ----------------
 * Initial release
-

--- a/eea/facetednavigation/browser/stylesheets/edit.css
+++ b/eea/facetednavigation/browser/stylesheets/edit.css
@@ -183,6 +183,10 @@ table.listing {
   margin-top: 1em;
 }
 
+#faceted-edit-widgets-ajax input {
+  margin-right: 0.5em;
+}
+
 #faceted-page-title {
   padding-right: 0px;
 }

--- a/eea/facetednavigation/docs/exportimport.txt
+++ b/eea/facetednavigation/docs/exportimport.txt
@@ -311,3 +311,149 @@ Let's see our new configuration
     </object>
 
 
+Test the criteria purge attribute
+---------------------------------
+
+Import a xml file with purge set to False, new criteria will be added to existing ones
+
+    >>> query = {
+    ...   'import_button': 'Import',
+    ...   'import_file': self.loadfile('data/with_purge_false.xml'),
+    ...   'redirect': '',
+    ... }
+    >>> view(**query)
+    u'Configuration imported'
+
+    >>> query = {
+    ...   'export_button': 'Export',
+    ...   'redirect': '',
+    ... }
+    >>> print view(**query)
+    <?xml version="1.0"?>
+    <object name="new_sandbox" meta_type="ATFolder">
+     <criteria>
+      <criterion name="c7">
+       <property name="widget">checkbox</property>
+       <property name="title">Type d'element</property>
+       <property name="position">left</property>
+       <property name="section">default</property>
+       <property name="hidden">1</property>
+       <property name="count">1</property>
+       <property name="index">portal_type</property>
+       <property name="vocabulary"></property>
+       <property name="default">
+        <element value="Folder"/>
+        <element value="Document"/>
+       </property>
+      </criterion>
+      <criterion name="c2">
+       <property name="widget">tagscloud</property>
+       <property name="title">Meta-type d'element</property>
+       <property name="position">top</property>
+       <property name="section">default</property>
+       <property name="hidden">0</property>
+       <property name="count"></property>
+       <property name="index">meta_type</property>
+       <property name="vocabulary"></property>
+       <property name="cloud">sphere</property>
+       <property name="default">ATFolder</property>
+      </criterion>
+      <criterion name="c10">
+        <property name="widget">daterange</property>
+        <property name="title">Modified</property>
+        <property name="position">top</property>
+        <property name="section">advanced</property>
+        <property name="hidden">0</property>
+        <property name="index">Date</property>
+        <property name="default"></property>
+        <property name="calYearRange">c-10:c+10</property>
+       </criterion>
+     </criteria>
+    </object>
+
+Importing an already existing criterion will not fail, it is just ignored and a warning is added to the Zope log
+    >>> query = {
+    ...   'import_button': 'Import',
+    ...   'import_file': self.loadfile('data/with_purge_false.xml'),
+    ...   'redirect': '',
+    ... }
+    >>> view(**query)
+    u'Configuration imported'
+    >>> query = {
+    ...   'export_button': 'Export',
+    ...   'redirect': '',
+    ... }
+
+    >>> print view(**query)
+    <?xml version="1.0"?>
+    <object name="new_sandbox" meta_type="ATFolder">
+     <criteria>
+      <criterion name="c7">
+       <property name="widget">checkbox</property>
+       <property name="title">Type d'element</property>
+       <property name="position">left</property>
+       <property name="section">default</property>
+       <property name="hidden">1</property>
+       <property name="count">1</property>
+       <property name="index">portal_type</property>
+       <property name="vocabulary"></property>
+       <property name="default">
+        <element value="Folder"/>
+        <element value="Document"/>
+       </property>
+      </criterion>
+      <criterion name="c2">
+       <property name="widget">tagscloud</property>
+       <property name="title">Meta-type d'element</property>
+       <property name="position">top</property>
+       <property name="section">default</property>
+       <property name="hidden">0</property>
+       <property name="count"></property>
+       <property name="index">meta_type</property>
+       <property name="vocabulary"></property>
+       <property name="cloud">sphere</property>
+       <property name="default">ATFolder</property>
+      </criterion>
+      <criterion name="c10">
+        <property name="widget">daterange</property>
+        <property name="title">Modified</property>
+        <property name="position">top</property>
+        <property name="section">advanced</property>
+        <property name="hidden">0</property>
+        <property name="index">Date</property>
+        <property name="default"></property>
+        <property name="calYearRange">c-10:c+10</property>
+       </criterion>
+     </criteria>
+    </object>
+
+Import a xml file with purge set to True (default), existing criteria are removed and the new is imported
+
+    >>> query = {
+    ...   'import_button': 'Import',
+    ...   'import_file': self.loadfile('data/with_purge_true.xml'),
+    ...   'redirect': '',
+    ... }
+    >>> view(**query)
+    u'Configuration imported'
+
+    >>> query = {
+    ...   'export_button': 'Export',
+    ...   'redirect': '',
+    ... }
+    >>> print view(**query)
+    <?xml version="1.0"?>
+    <object name="new_sandbox" meta_type="ATFolder">
+     <criteria>
+      <criterion name="c22">
+        <property name="widget">daterange</property>
+        <property name="title">Created</property>
+        <property name="position">top</property>
+        <property name="section">advanced</property>
+        <property name="hidden">0</property>
+        <property name="index">Date</property>
+        <property name="default"></property>
+        <property name="calYearRange">c-10:c+10</property>
+       </criterion>
+     </criteria>
+    </object>

--- a/eea/facetednavigation/docs/exportimport.txt
+++ b/eea/facetednavigation/docs/exportimport.txt
@@ -372,6 +372,7 @@ Import a xml file with purge set to False, new criteria will be added to existin
     </object>
 
 Importing an already existing criterion will not fail, it is just ignored and a warning is added to the Zope log
+
     >>> query = {
     ...   'import_button': 'Import',
     ...   'import_file': self.loadfile('data/with_purge_false.xml'),

--- a/eea/facetednavigation/tests/data/with_purge_false.xml
+++ b/eea/facetednavigation/tests/data/with_purge_false.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<object name="sandbox" meta_type="ATFolder">
+ <criteria purge="False">
+  <criterion name="c10">
+   <property name="widget">daterange</property>
+   <property name="title">Modified</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">0</property>
+   <property name="index">Date</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
+ </criteria>
+</object>

--- a/eea/facetednavigation/tests/data/with_purge_true.xml
+++ b/eea/facetednavigation/tests/data/with_purge_true.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<object name="sandbox" meta_type="ATFolder">
+ <criteria purge="True">
+  <criterion name="c22">
+   <property name="widget">daterange</property>
+   <property name="title">Created</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">0</property>
+   <property name="index">Date</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
+ </criteria>
+</object>


### PR DESCRIPTION
Hi @alecghica @avoinea 

this PR adapts the GenericSetup import step to take into account the "purge" paramter at the "<criteria>" level.  For now existing criteria are systematically removed and replaced with new imported XML.  Here, if you specify a "purge=False" in the new XML file (by default it behaves like if "purge=True"), existing criteria are kept and new ones are added.  If a criterion with same name already exist, it is not modified, and just ignored with a warning in the Zope log is added.

This is probably a first step, we could also manage the "purge" parameter at the "<criterion>" level to be able to specify this criterion by criterion.

I added relevant test.

Please review and merge ;-)

Gauthier