### PR TITLE
Sort ICriteria.criteria when a new criterion is added.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 -----------------------
 * Change: trigger an event just before a query is made by FacetedCatalog.
   [cedricmessiant]
+* Bug fix: Sort ICriteria.criteria when a new criterion is added.
+  [gbastien]
 
 8.2 - (2015-08-18)
 ------------------

--- a/eea/facetednavigation/criteria/handler.py
+++ b/eea/facetednavigation/criteria/handler.py
@@ -94,7 +94,18 @@ class Criteria(object):
 
         criterion = Criterion(widget=wid, position=position,
                               section=section, **properties)
-        criteria.append(criterion)
+
+        # insert the new criterion at the right place in criteria
+        voc = getUtility(IVocabularyFactory,
+                         'eea.faceted.vocabularies.WidgetPositions')
+        positions = [term.value for term in voc(self.context)]
+        # will be inserted at the end by default
+        insert_index = len(criteria)
+        for index, stored_criterion in enumerate(criteria):
+            if positions.index(position) < positions.index(stored_criterion.position):
+                insert_index = index
+                break
+        criteria.insert(insert_index, criterion)
         return criterion.getId()
 
     def delete(self, cid):

--- a/eea/facetednavigation/docs/browser.txt
+++ b/eea/facetednavigation/docs/browser.txt
@@ -179,6 +179,18 @@ Edit (no AJAX)
     <?xml version="1.0"?>
     <object name="sandbox" meta_type="ATFolder">
      <criteria>
+      <criterion name="c2">
+       <property name="widget">tagscloud</property>
+       <property name="title">Meta-type d'element</property>
+       <property name="position">top</property>
+       <property name="section">default</property>
+       <property name="hidden">0</property>
+       <property name="count"></property>
+       <property name="index">meta_type</property>
+       <property name="vocabulary"></property>
+       <property name="cloud">sphere</property>
+       <property name="default">ATFolder</property>
+      </criterion>
       <criterion name="c7">
        <property name="widget">checkbox</property>
        <property name="title">Type d'element</property>
@@ -192,18 +204,6 @@ Edit (no AJAX)
         <element value="Folder"/>
         <element value="Document"/>
        </property>
-      </criterion>
-      <criterion name="c2">
-       <property name="widget">tagscloud</property>
-       <property name="title">Meta-type d'element</property>
-       <property name="position">top</property>
-       <property name="section">default</property>
-       <property name="hidden">0</property>
-       <property name="count"></property>
-       <property name="index">meta_type</property>
-       <property name="vocabulary"></property>
-       <property name="cloud">sphere</property>
-       <property name="default">ATFolder</property>
       </criterion>
      </criteria>
     </object>

--- a/eea/facetednavigation/docs/criteria.txt
+++ b/eea/facetednavigation/docs/criteria.txt
@@ -32,14 +32,14 @@ Cleanup default widgets
 Add criteria
 ------------
 
-    >>> _ = ICriteria(sandbox).add('alphabetic', 'left')
-    >>> _ = ICriteria(sandbox).add('checkbox', 'left')
-    >>> _ = ICriteria(sandbox).add('criteria', 'right')
-    >>> _ = ICriteria(sandbox).add('daterange', 'right')
-    >>> _ = ICriteria(sandbox).add('radio', 'top')
-    >>> _ = ICriteria(sandbox).add('select', 'top')
-    >>> _ = ICriteria(sandbox).add('sorting', 'center')
-    >>> _ = ICriteria(sandbox).add('text', 'center')
+    >>> _ = ICriteria(sandbox).add('alphabetic', 'top')
+    >>> _ = ICriteria(sandbox).add('checkbox', 'top')
+    >>> _ = ICriteria(sandbox).add('criteria', 'left')
+    >>> _ = ICriteria(sandbox).add('daterange', 'left')
+    >>> _ = ICriteria(sandbox).add('radio', 'center')
+    >>> _ = ICriteria(sandbox).add('select', 'center')
+    >>> _ = ICriteria(sandbox).add('sorting', 'right')
+    >>> _ = ICriteria(sandbox).add('text', 'right')
 
 Get criteria
 ------------

--- a/eea/facetednavigation/docs/exportimport.txt
+++ b/eea/facetednavigation/docs/exportimport.txt
@@ -281,6 +281,18 @@ Let's see our new configuration
     <?xml version="1.0"?>
     <object name="new_sandbox" meta_type="ATFolder">
      <criteria>
+      <criterion name="c2">
+       <property name="widget">tagscloud</property>
+       <property name="title">Meta-type d'element</property>
+       <property name="position">top</property>
+       <property name="section">default</property>
+       <property name="hidden">0</property>
+       <property name="count"></property>
+       <property name="index">meta_type</property>
+       <property name="vocabulary"></property>
+       <property name="cloud">sphere</property>
+       <property name="default">ATFolder</property>
+      </criterion>
       <criterion name="c7">
        <property name="widget">checkbox</property>
        <property name="title">Type d'element</property>
@@ -294,18 +306,6 @@ Let's see our new configuration
         <element value="Folder"/>
         <element value="Document"/>
        </property>
-      </criterion>
-      <criterion name="c2">
-       <property name="widget">tagscloud</property>
-       <property name="title">Meta-type d'element</property>
-       <property name="position">top</property>
-       <property name="section">default</property>
-       <property name="hidden">0</property>
-       <property name="count"></property>
-       <property name="index">meta_type</property>
-       <property name="vocabulary"></property>
-       <property name="cloud">sphere</property>
-       <property name="default">ATFolder</property>
       </criterion>
      </criteria>
     </object>
@@ -332,20 +332,6 @@ Import a xml file with purge set to False, new criteria will be added to existin
     <?xml version="1.0"?>
     <object name="new_sandbox" meta_type="ATFolder">
      <criteria>
-      <criterion name="c7">
-       <property name="widget">checkbox</property>
-       <property name="title">Type d'element</property>
-       <property name="position">left</property>
-       <property name="section">default</property>
-       <property name="hidden">1</property>
-       <property name="count">1</property>
-       <property name="index">portal_type</property>
-       <property name="vocabulary"></property>
-       <property name="default">
-        <element value="Folder"/>
-        <element value="Document"/>
-       </property>
-      </criterion>
       <criterion name="c2">
        <property name="widget">tagscloud</property>
        <property name="title">Meta-type d'element</property>
@@ -368,6 +354,20 @@ Import a xml file with purge set to False, new criteria will be added to existin
         <property name="default"></property>
         <property name="calYearRange">c-10:c+10</property>
        </criterion>
+      <criterion name="c7">
+       <property name="widget">checkbox</property>
+       <property name="title">Type d'element</property>
+       <property name="position">left</property>
+       <property name="section">default</property>
+       <property name="hidden">1</property>
+       <property name="count">1</property>
+       <property name="index">portal_type</property>
+       <property name="vocabulary"></property>
+       <property name="default">
+        <element value="Folder"/>
+        <element value="Document"/>
+       </property>
+      </criterion>
      </criteria>
     </object>
 
@@ -389,20 +389,6 @@ Importing an already existing criterion will not fail, it is just ignored and a 
     <?xml version="1.0"?>
     <object name="new_sandbox" meta_type="ATFolder">
      <criteria>
-      <criterion name="c7">
-       <property name="widget">checkbox</property>
-       <property name="title">Type d'element</property>
-       <property name="position">left</property>
-       <property name="section">default</property>
-       <property name="hidden">1</property>
-       <property name="count">1</property>
-       <property name="index">portal_type</property>
-       <property name="vocabulary"></property>
-       <property name="default">
-        <element value="Folder"/>
-        <element value="Document"/>
-       </property>
-      </criterion>
       <criterion name="c2">
        <property name="widget">tagscloud</property>
        <property name="title">Meta-type d'element</property>
@@ -425,6 +411,20 @@ Importing an already existing criterion will not fail, it is just ignored and a 
         <property name="default"></property>
         <property name="calYearRange">c-10:c+10</property>
        </criterion>
+      <criterion name="c7">
+       <property name="widget">checkbox</property>
+       <property name="title">Type d'element</property>
+       <property name="position">left</property>
+       <property name="section">default</property>
+       <property name="hidden">1</property>
+       <property name="count">1</property>
+       <property name="index">portal_type</property>
+       <property name="vocabulary"></property>
+       <property name="default">
+        <element value="Folder"/>
+        <element value="Document"/>
+       </property>
+      </criterion>
      </criteria>
     </object>
 

--- a/eea/facetednavigation/exportimport/criteria.py
+++ b/eea/facetednavigation/exportimport/criteria.py
@@ -58,7 +58,12 @@ class CriteriaXMLAdapter(XMLAdapterBase):
 
             name = child.getAttribute('name')
             try:
-                cid = self.context.add('text', 'top', _cid_=name)
+                # we need to find the 'position' because it is used
+                # to sort criteria when the criterion is added
+                position = [subchild for subchild in child.getElementsByTagName('property')
+                            if subchild.getAttribute('name') == 'position']
+                position = position and position[0].childNodes[0].nodeValue or 'top'
+                cid = self.context.add('text', position, _cid_=name)
             except KeyError:
                 # element already exists, we log and we continue
                 # this could be the case if should_purge is False


### PR DESCRIPTION
Hi @avoinea 

I updated code so an newly added criterion will be inserted at the correct place in the ICriteria.criteria list of criteria.

I updated relevant tests and the GS import step as we need the position when adding the new criterion.

Could you please review and merge if everything is OK?

Thank you!

Gauthier

PS: I noticed on the https://pypi.python.org/pypi/eea.facetednavigation/#id1 page that changelog for version 8.2 is not complete ;-)