### PR TITLE
Use plone date format and language to render daterange widget

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,11 @@ Changelog
 
 9.0.dev0 - (unreleased)
 -----------------------
+* Feature: Add setting to allow the use of Plone date format and language to
+  render daterange widget and criteria label.
+  Old behavior (with format yy-mm-dd) is set by default and is still working
+  the same way as before to allow special years (like '0001').
+  [laulaz refs #99]
 * Feature: The daterange widget automatically restricts date range in end date
   calendar. 
   [laulaz refs #98]

--- a/eea/facetednavigation/widgets/daterange/edit.js
+++ b/eea/facetednavigation/widgets/daterange/edit.js
@@ -5,12 +5,13 @@ FacetedEdit.DateRangeWidget = function(wid){
   this.yearRange =  jQuery('input[name=calYearRange]', this.widget).val();
   this.start = jQuery('input[name=start]', this.widget);
   this.end = jQuery('input[name=end]', this.widget);
+  this.dateFormat = jQuery('input[name=dateFormat]', this.widget).val();
 
   var js_widget = this;
   this.start.datepicker({
     changeMonth: true,
     changeYear: true,
-    dateFormat: 'yy-mm-dd',
+    dateFormat: this.dateFormat,
     yearRange: this.yearRange,
     onSelect: function(date, cal){
       js_widget.force_range();
@@ -21,7 +22,7 @@ FacetedEdit.DateRangeWidget = function(wid){
   this.end.datepicker({
     changeMonth: true,
     changeYear: true,
-    dateFormat: 'yy-mm-dd',
+    dateFormat: this.dateFormat,
     yearRange: this.yearRange,
     onSelect: function(date, cal){
       js_widget.set_default(date);
@@ -63,8 +64,8 @@ FacetedEdit.DateRangeWidget.prototype = {
 
     var value = '';
     if(start && end){
-      var start_date = new Date(start.replace(/-/g, '/'));
-      var end_date = new Date(end.replace(/-/g, '/'));
+      var start_date = $.datepicker.parseDate(this.dateFormat, start);
+      var end_date = $.datepicker.parseDate(this.dateFormat, end);
       if(end_date<start_date){
         var msg = 'End Date should be greater than Start date';
         jQuery(FacetedEdit.Events).trigger(FacetedEdit.Events.AJAX_STOP, {msg: msg});

--- a/eea/facetednavigation/widgets/daterange/edit.js
+++ b/eea/facetednavigation/widgets/daterange/edit.js
@@ -5,6 +5,8 @@ FacetedEdit.DateRangeWidget = function(wid){
   this.yearRange =  jQuery('input[name=calYearRange]', this.widget).val();
   this.start = jQuery('input[name=start]', this.widget);
   this.end = jQuery('input[name=end]', this.widget);
+  this.usePloneFormat = jQuery('input[name=usePloneFormat]', this.widget).val();
+  this.usePloneFormat = this.usePloneFormat == "True" ? true : false;
   this.dateFormat = jQuery('input[name=dateFormat]', this.widget).val();
 
   var js_widget = this;
@@ -64,8 +66,15 @@ FacetedEdit.DateRangeWidget.prototype = {
 
     var value = '';
     if(start && end){
-      var start_date = $.datepicker.parseDate(this.dateFormat, start);
-      var end_date = $.datepicker.parseDate(this.dateFormat, end);
+      var start_date;
+      var end_date;
+      if(this.usePloneFormat){
+        start_date = $.datepicker.parseDate(this.dateFormat, start);
+        end_date = $.datepicker.parseDate(this.dateFormat, end);
+      }else{
+        start_date = new Date(start.replace(/-/g, '/'));
+        end_date = new Date(end.replace(/-/g, '/'));
+      }
       if(end_date<start_date){
         var msg = 'End Date should be greater than Start date';
         jQuery(FacetedEdit.Events).trigger(FacetedEdit.Events.AJAX_STOP, {msg: msg});

--- a/eea/facetednavigation/widgets/daterange/view.js
+++ b/eea/facetednavigation/widgets/daterange/view.js
@@ -10,6 +10,8 @@ Faceted.DateRangeWidget = function(wid){
   this.yearRange =  jQuery('input[name=calYearRange]', this.widget).val();
   this.end = jQuery('input[name=end]', this.widget);
   this.selected = [];
+  this.dateFormat = jQuery('input[name=dateFormat]', this.widget).val();
+  this.language = jQuery('input[name=language]', this.widget).val();
 
   var start = this.start.val();
   var end = this.end.val();
@@ -22,7 +24,7 @@ Faceted.DateRangeWidget = function(wid){
   this.start.datepicker({
     changeMonth: true,
     changeYear: true,
-    dateFormat: 'yy-mm-dd',
+    dateFormat: this.dateFormat,
     yearRange: this.yearRange,
     onSelect: function(date, cal){
       js_widget.force_range();
@@ -34,7 +36,7 @@ Faceted.DateRangeWidget = function(wid){
     changeMonth: true,
     changeYear: true,
     yearRange: this.yearRange,
-    dateFormat: 'yy-mm-dd',
+    dateFormat: this.dateFormat,
     onSelect: function(date, cal){
       js_widget.select_change(js_widget.end);
     }
@@ -116,8 +118,8 @@ Faceted.DateRangeWidget.prototype = {
     }
 
     var value = [start, end];
-    var start_date = new Date(start.replace(/-/g, '/'));
-    var end_date = new Date(end.replace(/-/g, '/'));
+    var start_date = $.datepicker.parseDate(this.dateFormat, value[0]);
+    var end_date = $.datepicker.parseDate(this.dateFormat, value[1]);
 
     if(end_date<start_date){
       Faceted.Form.raise_error(Faceted.DateRangeErrorMsg,
@@ -153,8 +155,8 @@ Faceted.DateRangeWidget.prototype = {
 
     var start = value[0];
     var end = value[1];
-    var start_date = new Date(start.replace(/-/g, '/'));
-    var end_date = new Date(end.replace(/-/g, '/'));
+    var start_date = $.datepicker.parseDate(this.dateFormat, start);
+    var end_date = $.datepicker.parseDate(this.dateFormat, end);
 
     // Invalid date
     if(!start_date.getFullYear()){
@@ -216,8 +218,8 @@ Faceted.DateRangeWidget.prototype = {
     html.attr('id', 'criteria_' + this.wid + '_entries');
     var start = this.start.val();
     var end = this.end.val();
-    var start_date = new Date(start.replace(/-/g, '/'));
-    var end_date = new Date(end.replace(/-/g, '/'));
+    var start_date = $.datepicker.parseDate(this.dateFormat, start);
+    var end_date = $.datepicker.parseDate(this.dateFormat, end);
 
     var label = this.criteria_label(start_date, end_date);
     var link = jQuery('<a href="#">[X]</a>');
@@ -236,7 +238,17 @@ Faceted.DateRangeWidget.prototype = {
   },
 
   criteria_label: function(start_date, end_date){
-    return start_date.toDateString() + ' - ' + end_date.toDateString();
+    if (this.language){
+      var options = {weekday: "short",
+                     year: "numeric",
+                     month: "short",
+                     day: "numeric"};
+      var start_date_label = start_date.toLocaleDateString(this.language, options);
+      var end_date_label = end_date.toLocaleDateString(this.language, options);
+      return start_date_label + ' - ' + end_date_label;
+    }else{
+      return start_date.toDateString() + ' - ' + end_date.toDateString();
+    }
   },
 
   criteria_remove: function(){

--- a/eea/facetednavigation/widgets/daterange/view.js
+++ b/eea/facetednavigation/widgets/daterange/view.js
@@ -10,6 +10,8 @@ Faceted.DateRangeWidget = function(wid){
   this.yearRange =  jQuery('input[name=calYearRange]', this.widget).val();
   this.end = jQuery('input[name=end]', this.widget);
   this.selected = [];
+  this.usePloneFormat = jQuery('input[name=usePloneFormat]', this.widget).val();
+  this.usePloneFormat = this.usePloneFormat == "True" ? true : false;
   this.dateFormat = jQuery('input[name=dateFormat]', this.widget).val();
   this.language = jQuery('input[name=language]', this.widget).val();
 
@@ -118,8 +120,15 @@ Faceted.DateRangeWidget.prototype = {
     }
 
     var value = [start, end];
-    var start_date = $.datepicker.parseDate(this.dateFormat, value[0]);
-    var end_date = $.datepicker.parseDate(this.dateFormat, value[1]);
+    var start_date;
+    var end_date;
+    if (this.usePloneFormat){
+      start_date = $.datepicker.parseDate(this.dateFormat, start);
+      end_date = $.datepicker.parseDate(this.dateFormat, end);
+    }else{
+      start_date = new Date(start.replace(/-/g, '/'));
+      end_date = new Date(end.replace(/-/g, '/'));
+    }
 
     if(end_date<start_date){
       Faceted.Form.raise_error(Faceted.DateRangeErrorMsg,
@@ -155,8 +164,15 @@ Faceted.DateRangeWidget.prototype = {
 
     var start = value[0];
     var end = value[1];
-    var start_date = $.datepicker.parseDate(this.dateFormat, start);
-    var end_date = $.datepicker.parseDate(this.dateFormat, end);
+    var start_date;
+    var end_date;
+    if (this.usePloneFormat){
+      start_date = $.datepicker.parseDate(this.dateFormat, start);
+      end_date = $.datepicker.parseDate(this.dateFormat, end);
+    }else{
+      start_date = new Date(start.replace(/-/g, '/'));
+      end_date = new Date(end.replace(/-/g, '/'));
+    }
 
     // Invalid date
     if(!start_date.getFullYear()){
@@ -218,8 +234,15 @@ Faceted.DateRangeWidget.prototype = {
     html.attr('id', 'criteria_' + this.wid + '_entries');
     var start = this.start.val();
     var end = this.end.val();
-    var start_date = $.datepicker.parseDate(this.dateFormat, start);
-    var end_date = $.datepicker.parseDate(this.dateFormat, end);
+    var start_date;
+    var end_date;
+    if (this.usePloneFormat){
+      start_date = $.datepicker.parseDate(this.dateFormat, start);
+      end_date = $.datepicker.parseDate(this.dateFormat, end);
+    }else{
+      start_date = new Date(start.replace(/-/g, '/'));
+      end_date = new Date(end.replace(/-/g, '/'));
+    }
 
     var label = this.criteria_label(start_date, end_date);
     var link = jQuery('<a href="#">[X]</a>');
@@ -238,7 +261,7 @@ Faceted.DateRangeWidget.prototype = {
   },
 
   criteria_label: function(start_date, end_date){
-    if (this.language){
+    if (this.usePloneFormat){
       var options = {weekday: "short",
                      year: "numeric",
                      month: "short",

--- a/eea/facetednavigation/widgets/daterange/widget.pt
+++ b/eea/facetednavigation/widgets/daterange/widget.pt
@@ -3,6 +3,7 @@
   error_view nocall:context/@@faceted.widget.error;
   wid python:view.data.getId();
   yearRange python:view.cal_year_range;
+  usePloneFormat python:view.use_plone_date_format;
   dateFormat python:view.js_date_format;
   language python:view.js_language;
   hidden python:view.hidden;
@@ -39,6 +40,9 @@
   <input type="hidden" name="calYearRange"
     tal:attributes="id string:${wid}_calYearRange;
     value string:$yearRange"/>
+  <input type="hidden" name="usePloneFormat"
+    tal:attributes="id string:${wid}_usePloneFormat;
+    value string:$usePloneFormat"/>
   <input type="hidden" name="dateFormat"
     tal:attributes="id string:${wid}_dateFormat;
     value string:$dateFormat"/>

--- a/eea/facetednavigation/widgets/daterange/widget.pt
+++ b/eea/facetednavigation/widgets/daterange/widget.pt
@@ -3,6 +3,8 @@
   error_view nocall:context/@@faceted.widget.error;
   wid python:view.data.getId();
   yearRange python:view.cal_year_range;
+  dateFormat python:view.js_date_format;
+  language python:view.js_language;
   hidden python:view.hidden;
   default_value python:view.default;
   default_start python:default_value[0];
@@ -37,6 +39,12 @@
   <input type="hidden" name="calYearRange"
     tal:attributes="id string:${wid}_calYearRange;
     value string:$yearRange"/>
+  <input type="hidden" name="dateFormat"
+    tal:attributes="id string:${wid}_dateFormat;
+    value string:$dateFormat"/>
+  <input type="hidden" name="language"
+    tal:attributes="id string:${wid}_language;
+    value string:$language"/>
 </form>
 
 </fieldset>

--- a/eea/facetednavigation/widgets/daterange/widget.py
+++ b/eea/facetednavigation/widgets/daterange/widget.py
@@ -144,15 +144,19 @@ class Widget(AbstractWidget, L10nDatepicker):
             return '', ''
 
         start, end = default
+        start = start.strip()
+        end = end.strip()
         try:
-            start = DateTime(start.strip())
+            start = DateTime(datetime.strptime(start,
+                                               self.python_date_format))
             start = start.strftime(self.python_date_format)
         except Exception, err:
             logger.exception('%s => Start date: %s', err, start)
             start = ''
 
         try:
-            end = DateTime(end.strip())
+            end = DateTime(datetime.strptime(end,
+                                             self.python_date_format))
             end = end.strftime(self.python_date_format)
         except Exception, err:
             logger.exception('%s => End date: %s', err, end)

--- a/eea/facetednavigation/widgets/daterange/widget.py
+++ b/eea/facetednavigation/widgets/daterange/widget.py
@@ -237,7 +237,7 @@ class Widget(AbstractWidget, L10nDatepicker):
 
     @property
     def js_language(self):
-        """Return the language to use with JS datepicker"""
+        """Return the language to use with JS code"""
         if self.use_plone_date_format:
             return self.jq_language()
         else:


### PR DESCRIPTION
Use setting to allow the use of Plone date format and language
Old behavior (with format yy-mm-dd) is set by default and is still working the same way as before to allow special years (like '0001').
This refs eea/eea.facetednavigation#99