### PR TITLE
Fix bug with html option tag with value containing spaces and empty value

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,11 @@ Changelog
 
 9.11.dev0 - (unreleased)
 ------------------------
+* Bug fix: Wrapped option values with quotes to avoid jQuery selector errors
+  with values containing spaces (jQuery >= 1.5.0) and empty values
+  (jQuery >=2.0.0)
+  [pdpotter]
+
 * Feature: Protect against slow IWidgetFilterBrains adapters
   [avoinea refs #83219]
 

--- a/eea/facetednavigation/widgets/resultsperpage/edit.js
+++ b/eea/facetednavigation/widgets/resultsperpage/edit.js
@@ -4,7 +4,7 @@ FacetedEdit.ResultsPerPageWidget = function(wid){
   this.elements = jQuery('option', this.widget);
   this.select = jQuery('#' + this.wid);
   var value = this.select.val();
-  this.selected = jQuery('option[value='+ value +']', this.widget);
+  this.selected = jQuery('option[value="'+ value +'"]', this.widget);
 
   // Handle change
   var js_widget = this;
@@ -16,7 +16,7 @@ FacetedEdit.ResultsPerPageWidget = function(wid){
 FacetedEdit.ResultsPerPageWidget.prototype = {
   set_default: function(element){
     var value = this.select.val();
-    this.selected = jQuery('option[value='+ value +']', this.widget);
+    this.selected = jQuery('option[value="'+ value +'"]', this.widget);
 
     var query = {};
     query.redirect = '';

--- a/eea/facetednavigation/widgets/resultsperpage/view.js
+++ b/eea/facetednavigation/widgets/resultsperpage/view.js
@@ -20,7 +20,7 @@ Faceted.ResultsPerPageWidget = function(wid) {
   // Default value
   var value = this.select.val();
   if (value) {
-    this.selected = jQuery('option[value=' + value + ']', this.widget);
+    this.selected = jQuery('option[value="' + value + '"]', this.widget);
     Faceted.Query[this.wid] = [ value ];
   }
 
@@ -47,7 +47,7 @@ Faceted.ResultsPerPageWidget.prototype = {
       return Faceted.Form.do_query(this.wid, []);
     } else {
       var value = jQuery(element).val();
-      this.selected = jQuery('#' + this.wid + '_widget option[value=' + value + ']');
+      this.selected = jQuery('#' + this.wid + '_widget option[value="' + value + '"]');
       return Faceted.Form.do_query(this.wid, value);
     }
   },
@@ -66,7 +66,7 @@ Faceted.ResultsPerPageWidget.prototype = {
 
   var context = this;
   jQuery.each(value, function() {
-    var selected = jQuery('#' + context.wid + '_widget option[value=' + value + ']');
+    var selected = jQuery('#' + context.wid + '_widget option[value="' + value + '"]');
     if (!selected.length) {
       context.reset();
     } else {

--- a/eea/facetednavigation/widgets/select/edit.js
+++ b/eea/facetednavigation/widgets/select/edit.js
@@ -4,7 +4,7 @@ FacetedEdit.SelectWidget = function(wid){
   this.elements = jQuery('option', this.widget);
   this.select = jQuery('#' + this.wid);
   var value = this.select.val();
-  this.selected = jQuery('option[value='+ value +']', this.widget);
+  this.selected = jQuery('option[value="'+ value +'"]', this.widget);
 
   // Handle change
   var js_widget = this;
@@ -31,7 +31,7 @@ FacetedEdit.SelectWidget.prototype = {
 
   set_default: function(element){
     var value = this.select.val();
-    this.selected = jQuery('option[value='+ value +']', this.widget);
+    this.selected = jQuery('option[value="'+ value +'"]', this.widget);
 
     var query = {};
     query.redirect = '';

--- a/eea/facetednavigation/widgets/select/view.js
+++ b/eea/facetednavigation/widgets/select/view.js
@@ -29,7 +29,7 @@ Faceted.SelectWidget = function(wid){
   // Default value
   var value = this.select.val();
   if(value){
-    this.selected = jQuery("option[value='" + value + "']", js_widget.widget);
+    this.selected = jQuery('option[value="' + value + '"]', js_widget.widget);
     Faceted.Query[this.wid] = [value];
   }
 
@@ -68,7 +68,7 @@ Faceted.SelectWidget.prototype = {
       return Faceted.Form.do_query(this.wid, []);
     }else{
       var value = jQuery(element).val();
-      this.selected = jQuery("#" + this.wid + "_widget option[value='" + value + "']");
+      this.selected = jQuery('#' + this.wid + '_widget option[value="' + value + '"]');
       return Faceted.Form.do_query(this.wid, value);
     }
   },
@@ -87,7 +87,7 @@ Faceted.SelectWidget.prototype = {
 
     var context = this;
     jQuery.each(value, function(){
-      var selected = jQuery("option[value='" + value + "']", context.widget);
+      var selected = jQuery('option[value="' + value + '"]', context.widget);
       if(!selected.length){
         context.reset();
       }else{

--- a/eea/facetednavigation/widgets/sorting/edit.js
+++ b/eea/facetednavigation/widgets/sorting/edit.js
@@ -6,7 +6,7 @@ FacetedEdit.SortingWidget = function(wid, context){
   this.select = jQuery('#' + this.wid);
 
   var value = this.select.val();
-  this.selected = jQuery('option[value=' + value + ']', this.widget);
+  this.selected = jQuery('option[value="' + value + '"]', this.widget);
 
   // Handle select change
   var js_widget = this;
@@ -22,7 +22,7 @@ FacetedEdit.SortingWidget = function(wid, context){
 FacetedEdit.SortingWidget.prototype = {
   set_default: function(element){
     var value = this.select.val();
-    this.selected = jQuery('option[value=' + value + ']', this.widget);
+    this.selected = jQuery('option[value="' + value + '"]', this.widget);
     if(this.reverse.attr('checked')){
       value += '(reverse)';
     }

--- a/eea/facetednavigation/widgets/sorting/view.js
+++ b/eea/facetednavigation/widgets/sorting/view.js
@@ -33,7 +33,7 @@ Faceted.SortingWidget = function(wid){
   // Default value
   var value = this.select.val();
   if(value){
-    this.selected = jQuery('option[value=' + value + ']', this.widget);
+    this.selected = jQuery('option[value="' + value + '"]', this.widget);
     Faceted.Query[this.wid] = [value];
 
     var reverse = this.reverse.attr('checked');
@@ -82,7 +82,7 @@ Faceted.SortingWidget.prototype = {
         this.selected = [];
         value = [];
       }else{
-        this.selected = jQuery('option[value='+ value +']', this.widget);
+        this.selected = jQuery('option[value="'+ value +'"]', this.widget);
       }
       Faceted.Form.do_query(this.wid, value);
       return;
@@ -116,7 +116,7 @@ Faceted.SortingWidget.prototype = {
 
     var context = this;
     jQuery.each(value, function(){
-      var selected = jQuery('option[value='+ value +']', this.widget);
+      var selected = jQuery('option[value="'+ value +'"]', this.widget);
       if(!selected.length){
         context.reset(reversed_value);
       }else{


### PR DESCRIPTION
The fix consists of wrapping the value with quotes to avoid jQuery selector problems with:
* values containing spaces (jQuery 1.5.0 or higher)
* empty values (jQuery 2.0.0 or higher)