### PR TITLE
The daterange widget restriction on end date must be the start date a…

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,9 @@ Changelog
 
 9.16.dev0 - (unreleased)
 ------------------------
+* Bug fix: The daterange widget restriction on end date must be the start date and not the day after.
+           The dates in range can be the same day (as before).
+  [sgeulette]
 
 9.15 - (2017-05-22)
 -------------------
@@ -891,4 +894,3 @@ Changelog
 1.0 (2009-10-30)
 ----------------
 * Initial release
-

--- a/eea/facetednavigation/widgets/daterange/edit.js
+++ b/eea/facetednavigation/widgets/daterange/edit.js
@@ -52,9 +52,7 @@ FacetedEdit.DateRangeWidget.prototype = {
     if(!start_date){
       return;
     }
-    var min_end_date = new Date(start_date.getTime());
-    min_end_date.setDate(start_date.getDate() + 1);
-    this.end.datepicker("option", "minDate", min_end_date);
+    this.end.datepicker("option", "minDate", start_date);
   },
 
   set_default: function(element){

--- a/eea/facetednavigation/widgets/daterange/view.js
+++ b/eea/facetednavigation/widgets/daterange/view.js
@@ -96,9 +96,7 @@ Faceted.DateRangeWidget.prototype = {
     if(!start_date){
       return;
     }
-    var min_end_date = new Date(start_date.getTime());
-    min_end_date.setDate(start_date.getDate() + 1);
-    this.end.datepicker("option", "minDate", min_end_date);
+    this.end.datepicker("option", "minDate", start_date);
   },
 
   do_query: function(element){


### PR DESCRIPTION
…nd not the day after. The dates in range can be the same day (as before).