### PR TITLE
Fix value for select widget on selected filters section when came back using the URL

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+13.2 - (unreleased)
+--------------------------
+* Fix an issue with select widget where the synchronized value is ignored
+  on the selected value section when value came from the URL
+  [mpeeters]
+
 13.1 - (2019-08-19)
 --------------------------
 * Change: added widget-body div wrapping content of criteria and alphabetic

--- a/eea/facetednavigation/widgets/select/view.js
+++ b/eea/facetednavigation/widgets/select/view.js
@@ -88,7 +88,7 @@ Faceted.SelectWidget.prototype = {
 
     var context = this;
     jQuery.each(value, function(){
-      var selected = context.widget.find('option:selected');
+      var selected = context.widget.find('option[value="'+ this + '"]');
       if(!selected.length){
         context.reset();
       }else{


### PR DESCRIPTION
Example of the bug : https://www.eea.europa.eu/publications#c11=5&c14=&c12=&b_start=0&c7=zh

The displayed selected language value is "English" instead of "Chinese"